### PR TITLE
add `packtest-url` parameter and fix Dockerfile args wrong formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ This is a simple tool to help with running the [PackTest](https://github.com/mis
 `packtest_runner [OPTIONS...] <PACK1> [PACK2] [PACK3] ...`
 
 #### Options
- - `--version`: The Minecraft version to use. PackTest only supports 1.19.4, and this is the default.
+ - `--minecraft-version`: The Minecraft version to use. PackTest only supports 1.20.4, and this is the default.
  - `--comma-separate`: If set, will read the packs from the first argument specified, and split it by commas into multiple packs. Do not add spaces between the packs.
+ - `--packtest-url`: The URL to use when downloading the PackTest jar.
  - `--github`: Shows extra messages in the output for GitHub actions to use.
 
 ### GitHub Actions

--- a/action.yml
+++ b/action.yml
@@ -17,4 +17,6 @@ runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
-    - ${{ inputs.packs }} ${{ inputs.minecraft-version }} ${{inputs.packtest-url}}
+    - ${{ inputs.packs }}
+    - ${{ inputs.minecraft-version }}
+    - ${{ inputs.packtest-url }}

--- a/action.yml
+++ b/action.yml
@@ -5,12 +5,16 @@ inputs:
   packs:
     description: 'Paths to packs to test, separated by commas'
     required: true
-  version:
+  minecraft-version:
     description: 'Minecraft version to use. Defaults to 1.20.4'
     required: false
     default: '1.20.4'
+  packtest-url:
+    description: 'packtest url to download from. Defaults to `https://github.com/misode/packtest/releases/download/v1.0.0-beta4/packtest-1.0.0-beta4.jar`'
+    required: false
+    default: 'https://github.com/misode/packtest/releases/download/v1.0.0-beta4/packtest-1.0.0-beta4.jar'
 runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
-    - ${{ inputs.packs }} ${{ inputs.version }}
+    - ${{ inputs.packs }} ${{ inputs.minecraft-version }} ${{inputs.packtest-url}}

--- a/run_action.sh
+++ b/run_action.sh
@@ -4,4 +4,4 @@ echo ::group::Build test runner::
 cd /packtest_runner && cargo build
 cd /github/workspace
 echo ::endgroup::
-/packtest_runner/target/debug/packtest_runner --comma-separate --github --version "$2" "$1"
+/packtest_runner/target/debug/packtest_runner --comma-separate "$1" --minecraft-version "$2" --packtest-url "$3" --github

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -11,8 +11,6 @@ use mcvm_core::{ConfigBuilder, InstanceConfiguration, InstanceKind, MCVMCore};
 use mcvm_mods::fabric_quilt;
 use mcvm_shared::{output, Side};
 
-const PACKTEST_URL: &str =
-    "https://github.com/misode/packtest/releases/download/v1.0.0-beta4/packtest-1.0.0-beta4.jar";
 const FABRIC_API_URL: &str =
     "https://cdn.modrinth.com/data/P7dR8mSH/versions/JQ07mKWY/fabric-api-0.91.3%2B1.20.4.jar";
 
@@ -40,10 +38,16 @@ async fn main() -> ExitCode {
 async fn run() -> anyhow::Result<bool> {
     let cli = Cli::parse();
 
-    let version = if let Some(version) = cli.version {
-        version
+    let minecraft_version = if let Some(minecraft_version) = cli.minecraft_version {
+        minecraft_version
     } else {
         "1.20.4".into()
+    };
+
+    let packtest_url = if let Some(packtest_url) = cli.packtest_url {
+        packtest_url
+    } else {
+        "https://github.com/misode/packtest/releases/download/v1.0.0-beta4/packtest-1.0.0-beta4.jar".into()
     };
 
     let mut o = output::Simple(output::MessageLevel::Trace);
@@ -53,9 +57,9 @@ async fn run() -> anyhow::Result<bool> {
     let core_config = ConfigBuilder::new().disable_hardlinks(true);
     let mut core = MCVMCore::with_config(core_config.build()).context("Failed to create core")?;
     let version_info = core
-        .get_version_info(version.clone())
+        .get_version_info(minecraft_version.clone())
         .await
-        .context("Failed to get version info")?;
+        .context("Failed to get Minecraft version info")?;
 
     let stupid = download::text(
         "https://meta.fabricmc.net/v2/versions/loader/1.20.4",
@@ -76,9 +80,9 @@ async fn run() -> anyhow::Result<bool> {
     .context("Failed to install Fabric/Quilt")?;
 
     let mut vers = core
-        .get_version(&MinecraftVersion::Version(version.into()), &mut o)
+        .get_version(&MinecraftVersion::Version(minecraft_version.into()), &mut o)
         .await
-        .context("Failed to create version")?;
+        .context("Failed to create Minecraft version")?;
 
     let inst_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("packtest_launch");
     let mut launch_config = LaunchConfiguration::new();
@@ -106,14 +110,14 @@ async fn run() -> anyhow::Result<bool> {
     }
     // Download the mods
     download::file(
-        FABRIC_API_URL,
+        packtest_url,
         &mods_dir.join("packtest.jar"),
         &reqwest::Client::new(),
     )
     .await
     .context("Failed to download Packtest mod")?;
     download::file(
-        PACKTEST_URL,
+        FABRIC_API_URL,
         &mods_dir.join("fabric_api.jar"),
         &reqwest::Client::new(),
     )
@@ -180,9 +184,13 @@ struct Cli {
 
     /// Minecraft version to use. Defaults to 1.20.4
     #[arg(short, long)]
-    version: Option<String>,
+    minecraft_version: Option<String>,
 
     /// The packs to test. They must all be datapacks with the mcmeta
     /// in the root directory
     packs: Vec<String>,
+
+    /// packtest version to use. Defaults to URL for v1.0.0-beta4
+    #[arg(short, long)]
+    packtest_url: Option<String>,
 }

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -80,7 +80,7 @@ async fn run() -> anyhow::Result<bool> {
         .await
         .context("Failed to create version")?;
 
-    let inst_dir = PathBuf::from("./packtest_launch");
+    let inst_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("packtest_launch");
     let mut launch_config = LaunchConfiguration::new();
     launch_config.jvm_args = vec!["-Dpacktest.auto".into()];
     let inst_config = InstanceConfiguration {

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -61,14 +61,6 @@ async fn run() -> anyhow::Result<bool> {
         .await
         .context("Failed to get Minecraft version info")?;
 
-    let stupid = download::text(
-        "https://meta.fabricmc.net/v2/versions/loader/1.20.4",
-        core.get_client(),
-    )
-    .await
-    .context("Failed to do stupid thing")?;
-    dbg!(&stupid);
-
     let (classpath, main_class) = fabric_quilt::install_from_core(
         &mut core,
         &version_info,


### PR DESCRIPTION
problem was we were inputting `args` incorrectly into the `Dockerfile`. found this by echoing `$1`, `$2`, and `$3` in `run_action.sh`

full log: https://github.com/TheAfroOfDoom/omega-flowey-minecraft-remastered/actions/runs/7293134215/job/19875591995#step:4:361
```
Build test runner::
packs datapacks/omega-flowey 1.20.4 https://github.com/misode/packtest/releases/download/v1.0.0-beta4/packtest-1.0.0-beta4.jar
mcversion
packtesturl
```

**proof of fix**:
- https://github.com/TheAfroOfDoom/omega-flowey-minecraft-remastered/commit/26d72475feba3750ae34b6493e7c1e9835ad9a48
- https://github.com/TheAfroOfDoom/omega-flowey-minecraft-remastered/actions/runs/7293317214/job/19876116493#step:4:497

---

commit i initially narrowed down the failure to: https://github.com/TheAfroOfDoom/packtest_runner/commit/7bdfc353afb84182d94c839a6222602351439481

---

~commit/diff that initially broke it: https://github.com/CarbonSmasher/packtest_runner/commit/14ab29055778e167d28dab2fa36e3ea3e885db99#diff-47da617fb1b2f4ac52d72ac9c4679b892776c77aab9fcc0067f97a9f234de7f9L75~

^ this only broke it for me locally. still worth reverting tho.